### PR TITLE
ci(renovate): replace matchSourceUrls with matchPackageNames in rehua-pin

### DIFF
--- a/.github/renovate/rehua-pin.json
+++ b/.github/renovate/rehua-pin.json
@@ -3,7 +3,8 @@
 
     "packageRules": [
         {
-            "matchSourceUrls": ["https://github.com/BozhanL/rehua"],
+            "matchDatasources": ["docker"],
+            "matchPackageNames": ["ghcr.io/bozhanl/rehua-*"],
             "matchUpdateTypes": ["pinDigest"],
             "enabled": false
         }


### PR DESCRIPTION
…-pin

It seems renovate does not support matchSourceUrls for this docker image

<!-- markdownlint-disable headings -->

<!-- This template is inspired by the Angular PR template https://github.com/angular/angular/blob/main/.github/PULL_REQUEST_TEMPLATE.md -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Related code repository PR or ticket ID has been included below (if applicable)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix: <!-- insert description here -->
- [ ] Feature: <!-- Add feature name or id here -->
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (e.g. dependency updates, npm scripts, etc.)
- [x] CI/CD related changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [x] No
- [ ] Yes, described below:

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
